### PR TITLE
Fix docker-compose call after certificate update

### DIFF
--- a/data/ssl_certificate_renew.sh
+++ b/data/ssl_certificate_renew.sh
@@ -7,4 +7,5 @@ docker run -t --rm \
 
 # Ensure that docker-compose.yml is accessible via `/home/ec2-user/redash-setup/data/docker-compose.yml` path
 # or change `/home/ec2-user/redash-setup/data/docker-compose.yml` to path to Redash compose file.
-docker-compose -f /home/ec2-user/redash-setup/data/docker-compose.yml exec nginx nginx -s reload
+# Also please ensure that `/usr/local/bin/docker-compose` is path to docker-compose binary.
+/usr/local/bin/docker-compose -f /home/ec2-user/redash-setup/data/docker-compose.yml exec nginx nginx -s reload


### PR DESCRIPTION
## Description
Use `/usr/local/bin/docker-compose` to perform Nginx restart to avoid crontab error:
```
/home/ec2-user/redash-setup/data/ssl_certificate_renew.sh: line 10: docker-compose: command not found
```
## Screenshots
### Error
<img width="821" alt="Screenshot 2023-07-28 at 12 19 51" src="https://github.com/relay-commerce/redash-setup/assets/26375494/18bff11b-0c52-4f90-90fd-c2f0e22af182">

### Certificate updated after command fix
![Screenshot 2023-07-28 at 12 24 11](https://github.com/relay-commerce/redash-setup/assets/26375494/4929433e-fbdc-4411-8a95-23f02667573e)
